### PR TITLE
update readme and fix ImageDraw size bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python netease_lyric.py --sid 35476049 -t 1 -r 2
 
 例2. 根据歌单`id`生成歌单下所有歌曲的歌词图片，图片样式为`3`：
 ```
-python netease_lyric.py --gid 138688333 -t 3
+python netease_lyric.py --pid 138688333 -t 3
 ```
 
 例3. 根据歌曲`id`生成该歌的歌词，选取`1,3,6-9`行歌词：

--- a/netease_lyric.py
+++ b/netease_lyric.py
@@ -238,7 +238,7 @@ class Img():
     def save(self, name, lrc, img_url):
         lyric_font = ImageFont.truetype(self.font_family, self.font_size)
         banner_font = ImageFont.truetype(self.font_family, self.netease_banner_size)
-        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(0, 0))).textsize(lrc, font=lyric_font, spacing=self.line_space)
+        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(1, 1))).textsize(lrc, font=lyric_font, spacing=self.line_space)
 
         padding = self.padding
         w = self.share_img_width
@@ -288,7 +288,7 @@ class Img():
     def save2(self, name, lrc, img_url):
         lyric_font = ImageFont.truetype(self.font_family, self.font_size)
         banner_font = ImageFont.truetype(self.font_family, self.netease_banner_size)
-        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(0, 0))).textsize(lrc, font=lyric_font, spacing=self.line_space)
+        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(1, 1))).textsize(lrc, font=lyric_font, spacing=self.line_space)
 
         margin = self.style2_margin
         padding = self.style2_padding
@@ -336,7 +336,7 @@ class Img():
     def save3(self, name, lrc, img_url):
         lyric_font = ImageFont.truetype(self.font_family, self.font_size)
         banner_font = ImageFont.truetype(self.font_family, self.netease_banner_size)
-        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(0, 0))).textsize(lrc, font=lyric_font, spacing=self.line_space)
+        lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(1, 1))).textsize(lrc, font=lyric_font, spacing=self.line_space)
 
         margin = self.style2_margin
         padding = self.style2_padding


### PR DESCRIPTION
- update readme.md 修改 修改命令行参数 --pid
- fix ImageDraw size bug，`ImageDraw.Draw`传入的`Image Size`要大于0,否则报如下错误：
```
Traceback (most recent call last):
  File "netease_lyric.py", line 477, in <module>
    main()
  File "netease_lyric.py", line 455, in main
    playlist.create_img(pic_style)
  File "netease_lyric.py", line 154, in create_img
    save_func(s_name, s_lrc, s_img)
  File "netease_lyric.py", line 339, in save3
    lyric_w, lyric_h = ImageDraw.Draw(Image.new(mode='RGB', size=(0, 0))).textsize(lrc, font=lyric_font, spacing=self.line_space)
  File "/home/sunnymarkliu/software/miniconda2/lib/python2.7/site-packages/PIL/Image.py", line 2021, in new
    _check_size(size)
  File "/home/sunnymarkliu/software/miniconda2/lib/python2.7/site-packages/PIL/Image.py", line 2001, in _check_size
    raise ValueError("Width and Height must be > 0")
ValueError: Width and Height must be > 0
```